### PR TITLE
Use Rubinius to 3.9 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ rvm:
   - "2.1"
   - "2.2"
   - "jruby-9.0.4.0"
-  - "rubinius-3.9"
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ rvm:
   - "2.1"
   - "2.2"
   - "jruby-9.0.4.0"
-  - "rbx-2.5.8"
+  - "rubinius-3.9"
 
 cache: bundler


### PR DESCRIPTION
Rubinius 2.5.8 doesn't exist on Travis anymore.