### PR TITLE
Fix Docker settings for tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,7 +32,7 @@ rescue Docker::Error::NotFoundError
     "Image" => image,
     "HostConfig" => {
       "PortBindings" => {
-        "#{port}/tcp" => [{ "HostPort" => port.to_s }]
+        "80/tcp" => [{ "HostPort" => port.to_s }]
       }
     }
   )


### PR DESCRIPTION
Hey Janko!

Thanks for the gem. 

[Looks like the author of the Docker image being used has exposed different port](https://github.com/requests/httpbin/commit/0d7f363f63e4e62acc1aa06174a5ed0f6b7e1383#diff-3254677a7917c6c01f55212f86c57fbf). Too bad he's not tagging images so we can't lock it to specific version.

This should make tests runable on Travis again.