### PR TITLE
Ensure url is valid when opening a redirect url

### DIFF
--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -117,7 +117,7 @@ module Down
     rescue OpenURI::HTTPRedirect => exception
       raise Down::TooManyRedirects, "too many redirects" if follows_remaining == 0
 
-      uri = exception.uri
+      uri = ensure_uri(exception.uri)
 
       if !exception.io.meta["set-cookie"].to_s.empty?
         options["Cookie"] = exception.io.meta["set-cookie"]
@@ -189,7 +189,7 @@ module Down
 
         location = uri + location if location.relative?
 
-        net_http_request(location, options, follows_remaining: follows_remaining - 1, &block)
+        net_http_request(ensure_uri(location), options, follows_remaining: follows_remaining - 1, &block)
       end
     end
 

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -219,6 +219,10 @@ describe Down do
       assert_raises(Down::InvalidUrl) { Down::NetHttp.download("| ls") }
     end
 
+    it "raises on invalid redirect url" do
+      assert_raises(Down::InvalidUrl) { Down::NetHttp.download("#{$httpbin}/redirect-to?url=#{CGI.escape("ftp://localhost/file.txt")}") }
+    end
+
     it "raises on connection errors" do
       assert_raises(Down::ConnectionError) { Down::NetHttp.download("http://localhost:99999") }
     end
@@ -347,6 +351,10 @@ describe Down do
     it "raises on invalid URLs" do
       assert_raises(Down::InvalidUrl) { Down::NetHttp.open("http:\\example.org") }
       assert_raises(Down::InvalidUrl) { Down::NetHttp.open("foo://example.org") }
+    end
+
+    it "raises on invalid redirect url" do
+      assert_raises(Down::InvalidUrl) { Down::NetHttp.open("#{$httpbin}/redirect-to?url=#{CGI.escape("ftp://localhost/file.txt")}") }
     end
 
     it "raises on connection errors" do


### PR DESCRIPTION
When a redirect is followed the URL isn't properly validated. This PR fixes that.