### PR TITLE
Adopt addressable while parsing urls

### DIFF
--- a/down.gemspec
+++ b/down.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "posix-spawn" unless RUBY_ENGINE == "jruby"
   spec.add_development_dependency "http_parser.rb"
   spec.add_development_dependency "docker-api"
+  spec.add_development_dependency "addressable", "~> 2.5"
 end

--- a/lib/down/backend.rb
+++ b/lib/down/backend.rb
@@ -6,18 +6,29 @@ require "down/errors"
 require "down/utils"
 
 require "fileutils"
+require "addressable/uri"
 
 module Down
   class Backend
     def self.download(*args, &block)
+      args[0] = normalize(args[0])
       new.download(*args, &block)
     end
 
     def self.open(*args, &block)
+      args[0] = normalize(args[0])
       new.open(*args, &block)
     end
 
     private
+
+    def self.normalize(url)
+      uri = Addressable::URI.parse(url).normalize
+      raise if uri.host.nil?
+      uri.to_s
+    rescue
+      raise Down::InvalidUrl
+    end
 
     def download_result(tempfile, destination)
       if destination

--- a/lib/down/backend.rb
+++ b/lib/down/backend.rb
@@ -11,18 +11,16 @@ require "addressable/uri"
 module Down
   class Backend
     def self.download(*args, &block)
-      args[0] = normalize(args[0])
       new.download(*args, &block)
     end
 
     def self.open(*args, &block)
-      args[0] = normalize(args[0])
       new.open(*args, &block)
     end
 
     private
 
-    def self.normalize(url)
+    def normalize(url)
       uri = Addressable::URI.parse(url).normalize
       raise if uri.host.nil?
       uri.to_s

--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -187,7 +187,7 @@ module Down
 
         # fail if redirect URI is not a valid http or https URL
         begin
-          location = ensure_uri(response["Location"], allow_relative: true)
+          location = ensure_uri(response["Location"], allow_relative: true, is_redirect: true)
         rescue Down::InvalidUrl
           raise ResponseError.new("Invalid Redirect URI: #{response["Location"]}", response: response)
         end
@@ -243,8 +243,9 @@ module Down
     end
 
     # Checks that the url is a valid URI and that it's http or https.
-    def ensure_uri(url, allow_relative: false)
+    def ensure_uri(url, allow_relative: false, is_redirect: false)
       begin
+        url = normalize(url) unless is_redirect
         uri = URI(url)
       rescue URI::InvalidURIError => exception
         raise Down::InvalidUrl, exception.message

--- a/lib/down/wget.rb
+++ b/lib/down/wget.rb
@@ -25,6 +25,7 @@ module Down
     end
 
     def download(url, *args, max_size: nil, content_length_proc: nil, progress_proc: nil, destination: nil, **options)
+      url = normalize(url)
       io = open(url, *args, **options, rewindable: false)
 
       content_length_proc.call(io.size) if content_length_proc && io.size
@@ -63,6 +64,7 @@ module Down
     end
 
     def open(url, *args, rewindable: true, **options)
+      url = normalize(url)
       arguments = generate_command(url, *args, **options)
 
       command = Down::Wget::Command.execute(arguments)

--- a/test/wget_test.rb
+++ b/test/wget_test.rb
@@ -249,7 +249,7 @@ describe Down::Wget do
     end
 
     it "raises on connection errors" do
-      assert_raises(Down::ConnectionError) { Down::Wget.open("localhost:9999") }
+      assert_raises(Down::ConnectionError) { Down::Wget.open("http://localhost:9999") }
     end
 
     it "raises on authentication failures" do


### PR DESCRIPTION
As discussed https://github.com/janko-m/down/issues/22, this PR uses `addressable` to pre-parse all urls.
@janko-m 